### PR TITLE
Test per-block continuous Put/GetMedia

### DIFF
--- a/kinesisvideomanager/consumer.go
+++ b/kinesisvideomanager/consumer.go
@@ -41,7 +41,7 @@ func (c *Client) Consumer(streamID StreamID) (*Consumer, error) {
 	}, nil
 }
 
-func (c *Consumer) GetMedia(ch chan *Cluster) (*Container, error) {
+func (c *Consumer) GetMedia(ch chan ebml.Block, chTag chan Tag) (*Container, error) {
 	body, err := json.Marshal(
 		&GetMediaBody{
 			StartSelector: StartSelector{
@@ -76,7 +76,8 @@ func (c *Consumer) GetMedia(ch chan *Cluster) (*Container, error) {
 	}
 	defer res.Body.Close()
 	data := &Container{}
-	data.Segment.Cluster = ch
+	data.Segment.Cluster.SimpleBlock = ch
+	data.Segment.Tags.Tag = chTag
 	if err := ebml.Unmarshal(res.Body, data); err != nil {
 		return nil, err
 	}

--- a/kinesisvideomanager/mkv.go
+++ b/kinesisvideomanager/mkv.go
@@ -39,8 +39,8 @@ type Tracks struct {
 }
 type Cluster struct {
 	Timecode    uint64
-	Position    uint64
-	SimpleBlock []ebml.Block
+	Position    uint64 `ebml:",omitempty"`
+	SimpleBlock chan ebml.Block
 }
 type SimpleTag struct {
 	TagName   string
@@ -51,11 +51,11 @@ type Tag struct {
 	SimpleTag []SimpleTag
 }
 type Tags struct {
-	Tag []Tag
+	Tag chan Tag `ebml:",omitempty"`
 }
 type Segment struct {
 	Info    Info
 	Tracks  Tracks
-	Cluster chan *Cluster `ebml:",size=unknown"`
-	Tags    []Tags
+	Cluster Cluster `ebml:",size=unknown"`
+	Tags    Tags
 }


### PR DESCRIPTION
PutMediaの時間制限が来る前に、並列で新しいコネクションを張って次のクラスタを書き込み始める。
古いコネクションは、アーカイブ状況のjsonが返ってきてから閉じられる。

GetMedia側は、Clusterの間にTags elementが挟まれていて、`AWS_KINESISVIDEO_CONTINUATION_TOKEN` が取り出せる。