### PR TITLE
Set timeout to avoid write timeout.

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -133,6 +133,9 @@ func (p *Provider) PutMedia(ch chan *BlockWithBaseTimecode, chTag chan *Tag, chR
 				// Forcefully switch to next connection
 				conn.close()
 				conn = nextConn
+				if conn != nil {
+					conn.timeout = time.After(options.connectionTimeout)
+				}
 				nextConn = nil
 			}
 		}


### PR DESCRIPTION
外部channelからのblockの供給が長時間止まったあとに再開されるとすでにタイムアウトしたコネクションに書き込もうとしてErrorになるため。一定時間経ったらchannelをcloseしてPutMediaのリクエストを終わらせる処理を入れる。デフォルト10秒 (コネクション交換のインターバルの9秒よりちょっと長めという設定) でオプションで変更可能。

Error例
```
read tcp 172.16.100.18:49978->13.115.104.100:443: use of closed network connection
github.com/seqsense/sq-video-gw/video-gateway/kinesis.(*Writer).Start.func2
  /Users/shinichi/go/src/github.com/seqsense/sq-video-gw/video-gateway/kinesis/writer.go:128
```