### PR TITLE
Add ErrorId and ErrorCode to the response struct of PutMedia

### DIFF
--- a/putresp.go
+++ b/putresp.go
@@ -9,6 +9,8 @@ type FragmentEvent struct {
 	EventType        string
 	FragmentTimecode uint64
 	FragmentNumber   string // 158-bit number, handle as string
+	ErrorId          int
+	ErrorCode        string
 }
 
 func parseFragmentEvent(r io.Reader) ([]FragmentEvent, error) {


### PR DESCRIPTION
現状Errorのレスポンスが帰ってきた場合, ErrorIdとErrorCodeが無いため、何のErrorになったか分からない。そのため、この2つを追加する。
https://docs.aws.amazon.com/ja_jp/kinesisvideostreams/latest/dg/API_dataplane_PutMedia.html#API_dataplane_PutMedia_ResponseSyntax