### PR TITLE
Add a nil check for response body.

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -162,7 +162,9 @@ func (p *Provider) putSegments(ch chan *BlockChWithBaseTimecode, chResp chan Fra
 		}
 		go func() {
 			res, err := p.putMedia(seg.Timecode, seg.Block, seg.Tag, opts)
-			defer res.Close()
+			if res != nil {
+				defer res.Close()
+			}
 			if err != nil {
 				chErr <- err
 				return


### PR DESCRIPTION
`putMedia` メソッドの抜け方によってはbodyがnilのことがあり、nilポインターで落ちることがあるため。