### PR TITLE
Generate producer timestamp in each PutMedia request

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/at-wat/ebml-go v0.10.0 h1:tTFY84VKOXkKj3aFBsufsdFEGqPhwE5SZQG55q7pT2c=
 github.com/at-wat/ebml-go v0.10.0/go.mod h1:w1cJs7zmGsb5nnSvhWGKLCxvfu4FVx5ERvYDIalj1ww=
 github.com/aws/aws-sdk-go v1.29.24 h1:KOnds/LwADMDBaALL4UB98ZR+TUR1A1mYmAYbdLixLA=
 github.com/aws/aws-sdk-go v1.29.24/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=

--- a/time.go
+++ b/time.go
@@ -1,0 +1,14 @@
+package kinesisvideomanager
+
+import (
+	"fmt"
+	"time"
+)
+
+func toProducerTimestamp(t time.Time) string {
+	unix := fmt.Sprintf("%d", t.Unix())
+	if millis := t.Nanosecond() / int(time.Millisecond); millis > 0 {
+		return fmt.Sprintf("%s.%03d", unix, millis)
+	}
+	return unix
+}

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,38 @@
+package kinesisvideomanager
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_toProducerTimestamp(t *testing.T) {
+	testCases := map[string]struct {
+		input    time.Time
+		expected string
+	}{
+		"MillisIsZero": {
+			time.Unix(1, int64(time.Millisecond-1)),
+			"1",
+		},
+		"MillisIsOneDigit": {
+			time.Unix(0, int64(time.Millisecond)),
+			"0.001",
+		},
+		"MillisIsTwoDigits": {
+			time.Unix(0, 12*int64(time.Millisecond)),
+			"0.012",
+		},
+		"MillisIsThreeDigits": {
+			time.Unix(0, 123*int64(time.Millisecond)),
+			"0.123",
+		},
+	}
+	for n, c := range testCases {
+		t.Run(n, func(t *testing.T) {
+			ts := toProducerTimestamp(c.input)
+			if ts != c.expected {
+				t.Errorf("Expected timestamp: '%v', got: '%v'", c.expected, ts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
PutMediaリクエストごとにProducerTimestampを生成したかったので、オプションを固定値ではなくfuncを渡すように修正する。あとProducerTimestampのstring変換処理がバグっていたので、メソッドに切り出してテストを追加。 (CIは別PRで対応)