### PR TITLE
Test with multiple Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,17 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - 1.15
+          - 1.16
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: ${{ matrix.go-version }}
 
       - name: Test
         run: |


### PR DESCRIPTION
Go 1.16 is released 🎉 , so I added test with Go 1.16 to existing tests.