### PR TITLE
Fix kinesis connection error handling

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,58 @@
+// Copyright 2020 SEQSENSE, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinesisvideomanager
+
+import (
+	"log"
+)
+
+func init() {
+	SetLogger(&testLogger{})
+}
+
+type testLogger struct {
+}
+
+func (n *testLogger) Debug(args ...interface{}) {
+	log.Print(args...)
+}
+
+func (n *testLogger) Debugf(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+func (n *testLogger) Info(args ...interface{}) {
+	log.Print(args...)
+}
+
+func (n *testLogger) Infof(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+func (n *testLogger) Warn(args ...interface{}) {
+	log.Print(args...)
+}
+
+func (n *testLogger) Warnf(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+func (n *testLogger) Error(args ...interface{}) {
+	log.Print(args...)
+}
+
+func (n *testLogger) Errorf(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -25,13 +25,8 @@ func init() {
 type testLogger struct {
 }
 
-func (n *testLogger) Debug(args ...interface{}) {
-	log.Print(args...)
-}
-
-func (n *testLogger) Debugf(format string, args ...interface{}) {
-	log.Printf(format, args...)
-}
+func (n *testLogger) Debug(args ...interface{})                 {}
+func (n *testLogger) Debugf(format string, args ...interface{}) {}
 
 func (n *testLogger) Info(args ...interface{}) {
 	log.Print(args...)

--- a/multierr.go
+++ b/multierr.go
@@ -1,0 +1,47 @@
+// Copyright 2021 SEQSENSE, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinesisvideomanager
+
+import (
+	"errors"
+)
+
+type multiError []error
+
+func (me multiError) Error() string {
+	str := "multiple errors:"
+	for _, e := range me {
+		str += " '" + e.Error() + "'"
+	}
+	return str
+}
+
+func (me multiError) Is(err error) bool {
+	for _, e := range me {
+		if errors.Is(e, err) {
+			return true
+		}
+	}
+	return false
+}
+
+func (me multiError) As(target interface{}) bool {
+	for _, e := range me {
+		if errors.As(e, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/multierr.go
+++ b/multierr.go
@@ -20,6 +20,17 @@ import (
 
 type multiError []error
 
+func newMultiError(errs ...error) error {
+	var err multiError
+	for _, e := range errs {
+		err.Add(e)
+	}
+	if len(err) == 0 {
+		return nil
+	}
+	return err
+}
+
 func (me multiError) Error() string {
 	if len(me) == 1 {
 		return me[0].Error()

--- a/multierr.go
+++ b/multierr.go
@@ -48,3 +48,10 @@ func (me multiError) As(target interface{}) bool {
 	}
 	return false
 }
+
+func (me *multiError) Add(err error) {
+	if err == nil {
+		return
+	}
+	*me = append(*me, err)
+}

--- a/multierr.go
+++ b/multierr.go
@@ -21,6 +21,9 @@ import (
 type multiError []error
 
 func (me multiError) Error() string {
+	if len(me) == 1 {
+		return me[0].Error()
+	}
 	str := "multiple errors:"
 	for _, e := range me {
 		str += " '" + e.Error() + "'"

--- a/provider.go
+++ b/provider.go
@@ -330,11 +330,11 @@ func (p *Provider) putMedia(baseTimecode chan uint64, ch chan ebml.Block, chTag 
 
 		buf := bufio.NewWriter(w)
 		if err := ebml.Marshal(&data, buf); err != nil {
-			ctxErr.err = err
+			ctxErr.err = fmt.Errorf("ebml marshalling: %w", err)
 			return
 		}
 		if err := buf.Flush(); err != nil {
-			ctxErr.err = err
+			ctxErr.err = fmt.Errorf("buffer flushing: %w", err)
 			return
 		}
 	}()
@@ -367,7 +367,7 @@ func (c *errContext) Err() error {
 func (p *Provider) putMediaRaw(ctx context.Context, r io.Reader, opts *PutMediaOptions) (io.ReadCloser, error) {
 	req, err := http.NewRequest("POST", p.endpoint, r)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating http request: %w", err)
 	}
 	if p.streamID.StreamName() != nil {
 		req.Header.Set("x-amzn-stream-name", *p.streamID.StreamName())
@@ -384,16 +384,16 @@ func (p *Provider) putMediaRaw(ctx context.Context, r io.Reader, opts *PutMediaO
 		10*time.Minute, time.Now(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("presigning request: %w", err)
 	}
 	res, err := opts.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("sending http request: %w", err)
 	}
 	if res.StatusCode != 200 {
 		body, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("reading http response: %w", err)
 		}
 		return nil, fmt.Errorf("%d: %s", res.StatusCode, string(body))
 	}

--- a/provider.go
+++ b/provider.go
@@ -318,14 +318,13 @@ func (p *Provider) putMedia(baseTimecode chan uint64, ch chan ebml.Block, chTag 
 		// Ignore error when http request body is closed.
 		// Continue marshalling whole fragment and retry sending later.
 		noErrWriter := &ignoreErrWriter{Writer: wOutBuf}
-		w = io.Writer(noErrWriter)
 		writeErr = noErrWriter.Err
 
 		// Take copy of the fragment.
 		backup = p.bufferPool.Get().(*bytes.Buffer)
 		defer p.bufferPool.Put(backup)
 		backup.Reset()
-		w = io.MultiWriter(wOutBuf, backup)
+		w = io.MultiWriter(noErrWriter, backup)
 	} else {
 		w = io.Writer(wOutBuf)
 	}

--- a/provider_test.go
+++ b/provider_test.go
@@ -16,6 +16,7 @@ package kinesisvideomanager_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -205,7 +206,8 @@ func TestProvider_WithHttpClient(t *testing.T) {
 		kvm.WithHttpClient(client),
 		kvm.OnError(func(e error) { err = e }),
 	)
-	if nerr, ok := err.(net.Error); !ok || !nerr.Timeout() {
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
 		t.Fatalf("Err must be timeout error but %v", err)
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,44 @@
+// Copyright 2020 SEQSENSE, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinesisvideomanager
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+type ignoreErrWriter struct {
+	io.Writer
+	err atomic.Value // error
+}
+
+func (w *ignoreErrWriter) Write(b []byte) (int, error) {
+	if err := w.err.Load(); err != nil {
+		return len(b), nil
+	}
+	n, err := w.Writer.Write(b)
+	if err != nil {
+		w.err.Store(err)
+	}
+	return n, nil
+}
+
+func (w *ignoreErrWriter) Err() error {
+	err, ok := w.err.Load().(error)
+	if !ok {
+		return nil
+	}
+	return err
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 SEQSENSE, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinesisvideomanager
+
+import (
+	"errors"
+	"testing"
+)
+
+type dummyWriter struct {
+	err error
+}
+
+func (w *dummyWriter) Write(b []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	return len(b), nil
+}
+
+func TestIgnoreErrWriter(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		w := &ignoreErrWriter{Writer: &dummyWriter{}}
+		n, err := w.Write(make([]byte, 10))
+		if n != 10 {
+			t.Error("Write length differs")
+		}
+		if err != nil {
+			t.Error("ignoreErrWriter.Write must not return error")
+		}
+		if err := w.Err(); err != nil {
+			t.Errorf("Base writer didn't return error, but ignoreErrWriter stores error: '%v'", err)
+		}
+	})
+	t.Run("Error", func(t *testing.T) {
+		dummyErr := errors.New("test")
+		w := &ignoreErrWriter{Writer: &dummyWriter{err: dummyErr}}
+		n, err := w.Write(make([]byte, 10))
+		if n != 0 {
+			t.Error("Write length differs")
+		}
+		if err != nil {
+			t.Error("ignoreErrWriter.Write must not return error")
+		}
+		if err := w.Err(); err != dummyErr {
+			t.Errorf("Expected to store '%v', but got '%v'", dummyErr, err)
+		}
+	})
+}


### PR DESCRIPTION
Ignore data write error when http request body reader is closed. Continue marshalling whole fragment and retry sending later.