### PR TITLE
Fix PutMedia retry buffer corruption on connection error

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -332,7 +332,7 @@ func (p *Provider) putMedia(conn *connection, chResp chan FragmentEvent, opts *P
 		backup = p.bufferPool.Get().(*bytes.Buffer)
 		defer p.bufferPool.Put(backup)
 		backup.Reset()
-		w = io.MultiWriter(noErrWriter, backup)
+		w = io.MultiWriter(backup, noErrWriter)
 	} else {
 		w = io.Writer(wOutBuf)
 	}

--- a/writer.go
+++ b/writer.go
@@ -28,11 +28,10 @@ func (w *ignoreErrWriter) Write(b []byte) (int, error) {
 	if err := w.err.Load(); err != nil {
 		return len(b), nil
 	}
-	n, err := w.Writer.Write(b)
-	if err != nil {
+	if _, err := w.Writer.Write(b); err != nil {
 		w.err.Store(err)
 	}
-	return n, nil
+	return len(b), nil
 }
 
 func (w *ignoreErrWriter) Err() error {

--- a/writer_test.go
+++ b/writer_test.go
@@ -48,7 +48,7 @@ func TestIgnoreErrWriter(t *testing.T) {
 		dummyErr := errors.New("test")
 		w := &ignoreErrWriter{Writer: &dummyWriter{err: dummyErr}}
 		n, err := w.Write(make([]byte, 10))
-		if n != 0 {
+		if n != 10 {
 			t.Error("Write length differs")
 		}
 		if err != nil {


### PR DESCRIPTION
`io.MultiWriter` doesn't write to the second writer if the first writer
returns `n != len(buf)`.