### PR TITLE
Split Error func from FragmentEvent

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -490,7 +490,7 @@ func (p *Provider) putMedia(ctx context.Context, conn *connection, chResp chan *
 			if err = p.putMediaRaw(ctx, &nopCloser{bytes.NewReader(backup.Bytes())}, chRespRaw, opts); err == nil {
 				break
 			}
-			if fe, ok := err.(*FragmentEvent); ok && opts.fragmentHeadDumpLen > 0 {
+			if fe, ok := err.(*FragmentEventError); ok && opts.fragmentHeadDumpLen > 0 {
 				bb := backup.Bytes()
 				if len(bb) > opts.fragmentHeadDumpLen {
 					fe.fragmentHead = bb[:opts.fragmentHeadDumpLen]
@@ -548,7 +548,7 @@ func (p *Provider) putMediaRaw(ctx context.Context, rc io.ReadCloser, chResp cha
 	go func() {
 		for fe := range chFE {
 			if fe.IsError() && err == nil {
-				chErr <- fe
+				chErr <- fe.AsError()
 			}
 			chResp <- fe
 		}

--- a/provider_test.go
+++ b/provider_test.go
@@ -174,9 +174,9 @@ func TestProvider(t *testing.T) {
 					// Skip first fragment.
 					return false
 				}
-				fe, ok := err.(*kvm.FragmentEvent)
+				fe, ok := err.(*kvm.FragmentEventError)
 				if !ok {
-					t.Errorf("Expected FragmentEvent, got %T", err)
+					t.Errorf("Expected FragmentEventError, got %T", err)
 					return false
 				}
 				expectedDump := []byte{
@@ -218,9 +218,9 @@ func TestProvider(t *testing.T) {
 					// Skip first fragment.
 					return false
 				}
-				fe, ok := err.(*kvm.FragmentEvent)
+				fe, ok := err.(*kvm.FragmentEventError)
 				if !ok {
-					t.Errorf("Expected FragmentEvent, got %T", err)
+					t.Errorf("Expected FragmentEventError, got %T", err)
 					return false
 				}
 				expectedDump := []byte{

--- a/putresp.go
+++ b/putresp.go
@@ -61,10 +61,22 @@ func (e *FragmentEvent) IsError() bool {
 	return e.EventType == "ERROR"
 }
 
-func (e *FragmentEvent) Error() string {
+func (e *FragmentEvent) AsError() error {
 	if e.EventType != "ERROR" {
 		panic("non-error FragmentEvent is used as error")
 	}
+	return &FragmentEventError{FragmentEvent: *e}
+}
+
+func (e *FragmentEvent) Dump() []byte {
+	return e.fragmentHead
+}
+
+type FragmentEventError struct {
+	FragmentEvent
+}
+
+func (e FragmentEventError) Error() string {
 	var dump string
 	if len(e.fragmentHead) > 0 {
 		dump = `, Data: "` + base64.RawStdEncoding.EncodeToString(e.fragmentHead) + `"`
@@ -72,10 +84,6 @@ func (e *FragmentEvent) Error() string {
 	return fmt.Sprintf(`fragment event error: { Timecode: %d, FragmentNumber: %s, ErrorId: %d, ErrorCode: "%s"%s }`,
 		e.FragmentTimecode, e.FragmentNumber, e.ErrorId, e.ErrorCode, dump,
 	)
-}
-
-func (e *FragmentEvent) Dump() []byte {
-	return e.fragmentHead
 }
 
 func parseFragmentEvent(r io.Reader, ch chan *FragmentEvent) error {

--- a/putresp_test.go
+++ b/putresp_test.go
@@ -45,14 +45,14 @@ func TestFragmentEvent(t *testing.T) {
 		}
 
 		expected := `fragment event error: { Timecode: 12345, FragmentNumber: 91343852333754009371412493862204112772176002064, ErrorId: 5000, ErrorCode: "DUMMY_ERROR" }`
-		if s := fe[0].Error(); s != expected {
+		if s := fe[0].AsError().Error(); s != expected {
 			t.Errorf("Expected error string:\n%s\ngot:\n%s", expected, s)
 		}
 
 		fe[0].fragmentHead = []byte("test")
 
 		expected2 := `fragment event error: { Timecode: 12345, FragmentNumber: 91343852333754009371412493862204112772176002064, ErrorId: 5000, ErrorCode: "DUMMY_ERROR", Data: "dGVzdA" }`
-		if s := fe[0].Error(); s != expected2 {
+		if s := fe[0].AsError().Error(); s != expected2 {
 			t.Errorf("Expected error string:\n%s\ngot:\n%s", expected2, s)
 		}
 	})


### PR DESCRIPTION
Fmt package handled *FragmentEvent as error as it had Error func.
(V1 API returned non-pointer so that fmt package didn't handle it as error, but v2 API returns pointer of FragmentEvent.)
Move Error function to FragmentEventError to avoid being handled as error.