### PR TITLE
Fix mediaflagment endpoint resolve error on dualstack mode

### DIFF
--- a/mediafragment/client.go
+++ b/mediafragment/client.go
@@ -63,6 +63,9 @@ func New(ctx context.Context, streamID kvm.StreamID, cfg aws.Config) (*Client, e
 	}
 	clientListFragments := kvam.NewFromConfig(cfg, func(o *kvam.Options) {
 		o.BaseEndpoint = epListFragments.DataEndpoint
+		// BaseEndpoint is already resolved based on AWS_USE_DUALSTACK_ENDPOINT.
+		// Need to disable dualstack flag to avoid endpoint resolve rule error.
+		o.EndpointOptions.UseDualStackEndpoint = aws.DualStackEndpointStateDisabled
 	})
 
 	epGetMediaForFragmentList, err := kv.GetDataEndpoint(ctx,
@@ -76,6 +79,9 @@ func New(ctx context.Context, streamID kvm.StreamID, cfg aws.Config) (*Client, e
 	}
 	clientGetMediaForFragmentList := kvam.NewFromConfig(cfg, func(o *kvam.Options) {
 		o.BaseEndpoint = epGetMediaForFragmentList.DataEndpoint
+		// BaseEndpoint is already resolved based on AWS_USE_DUALSTACK_ENDPOINT.
+		// Need to disable dualstack flag to avoid endpoint resolve rule error.
+		o.EndpointOptions.UseDualStackEndpoint = aws.DualStackEndpointStateDisabled
 	})
 
 	return &Client{


### PR DESCRIPTION
On `AWS_USE_DUALSTACK_ENDPOINT=true`, mediaflagment package failed with `operation error Kinesis Video Archived Media: ListFragments, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Dualstack and custom endpoint are not supported` error.

The error can be reproduced by running `./examples/getarchive` and confirmed to be fixed by this PR.